### PR TITLE
fix: add back cli entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
   "openjd-sessions == 0.1.*"
 ]
 
+[project.scripts]
+openjd = "openjd:__main__.main"
+
 
 [tool.hatch.build]
 artifacts = [


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)

When copying the library code over from our internal repository we missed defining the actual CLI entrypoint in this project's toml file. This remedies the oversight.

### What was the solution? (How)

Add the entrypoint definition to the pyproject.toml

### What is the impact of this change?

The CLI is now available.

### How was this change tested?

I've run both `openjd --help` and `python -m openjd --help` in a virtual environment with the package installed.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*