### PR TITLE
fix: add entrypoint to packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ only-include = [
   "src/openjd",
 ]
 
+[tool.hatch.build.targets.sdist.force-include]
+"src/openjd/__main__.py" = "openjd/__main__.py"
+
 [tool.hatch.build.targets.wheel]
 packages = [
   "src/openjd",
@@ -59,6 +62,9 @@ packages = [
 only-include = [
   "src/openjd",
 ]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/openjd/__main__.py" = "openjd/__main__.py"
 
 [tool.mypy]
 check_untyped_defs = false


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The entrypoint for the OpenJD CLI was not being correctly packaged with the sdist / wheel distributable artifacts.

### What was the solution? (How)

Modify the configuration to include the entrypoint file in the sdist / wheel using hatchling's [`force-include` feature](https://hatch.pypa.io/latest/config/build/#forced-inclusion).

### What is the impact of this change?

The distributions include the entrypoint.

### How was this change tested?

1.  Ran `hatch build`
2.  Inspected the built artifacts:
    1.  Ran `tar -tzf dist/*.tar.gz | grep "__main__.py"` which produced:

        ```
        openjd_cli-0.1.3.post0+geb6f2cd.d20231101/openjd/__main__.py
        ```
    2.  Ran `unzip -l dist/*.whl | grep "__main__.py"`, which produced:

        ```
              528  02-02-2020 00:00   openjd/__main__.py
        ```

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*