### PR TITLE
fix!: accept path mapping rules as per schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 requires-python = ">=3.9"
 
 dependencies = [
-  "openjd-sessions == 0.1.*"
+  "openjd-sessions == 0.2.*"
 ]
 
 [project.scripts]

--- a/src/openjd/cli/_common/__init__.py
+++ b/src/openjd/cli/_common/__init__.py
@@ -111,7 +111,7 @@ def generate_job(args: Namespace) -> Job:
 
 
 @dataclass
-class OpenJDCliResult:
+class OpenJDCliResult(BaseException):
     """
     Denotes the result of a command, including its status (success/error)
     and an accompanying message.

--- a/src/openjd/cli/_create_argparser.py
+++ b/src/openjd/cli/_create_argparser.py
@@ -17,7 +17,7 @@ from ._schema import populate_argparser as populate_schema_subparser
 
 def create_argparser() -> ArgumentParser:
     """Generate the root argparser for the CLI"""
-    parser = ArgumentParser(prog="openjd-cli", usage="openjd-cli <command> [arguments]")
+    parser = ArgumentParser(prog="openjd", usage="openjd <command> [arguments]")
     parser.set_defaults(func=lambda _: parser.print_help())
     subcommands = SubparserGroup(
         parser,

--- a/src/openjd/cli/_run/__init__.py
+++ b/src/openjd/cli/_run/__init__.py
@@ -9,7 +9,7 @@ def populate_argparser(subcommands: SubparserGroup) -> None:
     run_parser = subcommands.add(
         "run",
         description="Takes a Job Template and Step name, then runs Tasks from that Step.",
-        usage="openjd-cli-cli run JOB_TEMPLATE_PATH [arguments]",
+        usage="openjd run JOB_TEMPLATE_PATH [arguments]",
     )
     add_common_arguments(run_parser, {CommonArgument.PATH, CommonArgument.JOB_PARAMS})
     add_run_arguments(run_parser)

--- a/src/openjd/cli/_summary/__init__.py
+++ b/src/openjd/cli/_summary/__init__.py
@@ -8,7 +8,7 @@ def populate_argparser(subcommands: SubparserGroup) -> None:
     """Adds the `summary` command's arguments to the given subcommand parser."""
     summary_parser = subcommands.add(
         "summary",
-        usage="openjd-cli summary JOB_TEMPLATE_PATH [arguments]",
+        usage="openjd summary JOB_TEMPLATE_PATH [arguments]",
         description="Print summary information about a Job Template.",
     )
 

--- a/test/openjd/cli/test_run_command.py
+++ b/test/openjd/cli/test_run_command.py
@@ -17,7 +17,7 @@ from openjd.cli._run._run_command import (
 )
 from openjd.cli._run._local_session._session_manager import LocalSession
 from openjd.model import Job
-from openjd.sessions import PathMappingRule, PathMappingOS, Session
+from openjd.sessions import PathMappingRule, PathFormat, Session
 
 
 @pytest.mark.parametrize(
@@ -93,9 +93,19 @@ def test_do_run_path_mapping_rules():
     """
     Test that the `run` command exits on any error (e.g., a non-existent template file).
     """
-    path_mapping_rules = [
+    path_mapping_rules = {
+        "version": "pathmapping-1.0",
+        "path_mapping_rules": [
+            {
+                "source_path_format": "WINDOWS",
+                "source_path": r"C:\test",
+                "destination_path": "/mnt/test",
+            }
+        ],
+    }
+    expected_path_mapping_rules = [
         PathMappingRule(
-            source_os=PathMappingOS.WINDOWS,
+            source_path_format=PathFormat.WINDOWS,
             source_path=PureWindowsPath(r"C:\test"),
             destination_path=PurePosixPath("/mnt/test"),
         )
@@ -107,7 +117,7 @@ def test_do_run_path_mapping_rules():
         with tempfile.NamedTemporaryFile(
             mode="w+t", suffix=".rules.json", encoding="utf8", delete=False
         ) as temp_rules:
-            json.dump([rule.to_dict() for rule in path_mapping_rules], temp_rules.file)
+            json.dump(path_mapping_rules, temp_rules.file)
 
         with tempfile.NamedTemporaryFile(
             mode="w+t", suffix=".template.json", encoding="utf8", delete=False
@@ -136,7 +146,7 @@ def test_do_run_path_mapping_rules():
                 step_map=ANY,
                 maximum_tasks=1,
                 task_parameter_values=ANY,
-                path_mapping_rules=path_mapping_rules,
+                path_mapping_rules=expected_path_mapping_rules,
                 should_run_dependencies=False,
                 should_print_logs=True,
             )
@@ -232,7 +242,7 @@ def test_run_local_session_success(
     """
     path_mapping_rules = [
         PathMappingRule(
-            source_os=PathMappingOS.WINDOWS,
+            source_path_format=PathFormat.WINDOWS,
             source_path=PureWindowsPath(r"C:\test"),
             destination_path=PurePosixPath("/mnt/test"),
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

 The CLI run command currently accepts path mapping rules as a list of
rules using the old naming. Specifically:
```
[
 {"source_os": ..., "source_path": ...", "destination_path": ... },
 ...
]
```

 Open Job Description defines a schema for defining path mapping rules
that looks like:
```
{
   "version": "pathmapping-1.0",
   # The path_mapping_rules list will be empty if there are no path mapping rules defined
   "path_mapping_rules": [
      {
         # The path format that the submitting operating system uses
         "source_path_format": "POSIX" | "WINDOWS",
         # The filepath prefix to map (e.g. "/home/user" or "c:\Users\user")
         "source_path": <string>,
         # The location on the worker host where the path can be found
         # (e.g. "/mnt/shared/user" or "z:\")
         "destination_path": <string>
      },
      ...
   ]
}
```

### What was the solution? (How)

 This updates the CLI to accept the correct path mapping rules using the correct format. While in there, I also fixed a couple of small issues -- the cli command name being incorrect in help text, and a linter error saying that OpenJDCliResult must be derived from BaseException in Py3.11.

### What is the impact of this change?

The CLI command arguments are more in-line with the specification.

### How was this change tested?

I updated a unit test and ran the CLI.

### Was this change documented?

The schema is documented in the spec.

### Is this a breaking change?

Yes. The argument value for the `--path-mapping-rules` has changed.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*