### PR TITLE
fix: Allow job parameter values to be empty strings.

### DIFF
--- a/src/openjd/cli/_common/_job_from_template.py
+++ b/src/openjd/cli/_common/_job_from_template.py
@@ -75,7 +75,7 @@ def get_job_params(parameter_args: list[str]) -> dict:
 
         # Case 2: Provided argument is a Key=Value string
         else:
-            regex_match = re.match("(.+)=(.+)", arg)
+            regex_match = re.match("(.+)=(.*)", arg)
 
             if not regex_match:
                 raise RuntimeError(f"Job parameter '{arg}' should be in the format 'Key=Value'.")

--- a/test/openjd/test_main.py
+++ b/test/openjd/test_main.py
@@ -81,6 +81,10 @@ def test_cli_summary_success(mock_summary: Mock, mock_args: list):
             id="With multiple Job parameters",
         ),
         pytest.param(
+            ["some-template.json", "--step", "step1", "-p", "param=value1", "-p", "param2="],
+            id="With an empty string Job parameter value",
+        ),
+        pytest.param(
             [
                 "some-template.json",
                 "--step",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `openjd run` command prevents empty job parameters at the CLI.

### What was the solution? (How)

Modify the regex that validates this.

### What is the impact of this change?

Can pass empty values for string job parameters from the CLI.

### How was this change tested?

Added a unit test, tested it manually in the context where the problem was found.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*