### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @xxyggoqtpcmcofkc/Developers
+* @OpenJobDescription/Developers


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The GitHub organization name is being changed, and with it we need to update the reference to the old name in the codeowners file.

### What was the solution? (How)

Update CODEOWNERS.

### What is the impact of this change?

Someone cannot create a GitHub org with the old name to gain anything w.r.t. this repository.

### How was this change tested?

Can't be tested outside of GitHub

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*