### PR TITLE
feat!: Update openjd-cli to pass template_dir/cwd to preprocess_job_parameters

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -18,8 +18,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
-        os: [ubuntu-latest,macOS-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     env:
       PYTHON: ${{ matrix.python-version }}
       CODEARTIFACT_REGION: "us-west-2"
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       if: ${{ !inputs.branch }}
-      
+
     - uses: actions/checkout@v4
       if: ${{ inputs.branch }}
       with:
@@ -40,7 +40,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -48,13 +48,20 @@ jobs:
         aws-region: us-west-2
         mask-aws-account-id: true
 
+    - name: CodeArtifact Setup Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+
     - name: CodeArtifact Setup Linux/MacOS
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
         CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
         echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
         echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
-    
+
     - name: Install Dependencies
       run: pip install --upgrade -r requirements-development.txt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 requires-python = ">=3.9"
 
 dependencies = [
-  "openjd-sessions == 0.2.*"
+  "openjd-sessions == 0.3.*"
 ]
 
 [project.scripts]
@@ -125,7 +125,7 @@ addopts = [
     "--cov-report=xml:build/coverage/coverage.xml",
     "--cov-report=term-missing",
     "--numprocesses=auto",
-    "--timeout=30"
+    "--timeout=60"
 ]
 
 

--- a/src/openjd/cli/_common/__init__.py
+++ b/src/openjd/cli/_common/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Callable, Literal
 import json
 import yaml
+import os
 
 from ._job_from_template import (
     job_from_template,
@@ -100,14 +101,18 @@ class SubparserGroup:
 def generate_job(args: Namespace) -> Job:
     try:
         # Raises: RuntimeError, DecodeValidationError
-        _, template = read_template(args)
+        template_file, template = read_template(args)
         # Raises: RuntimeError
-        sample_job = job_from_template(template, args.job_params if args.job_params else None)
+        return job_from_template(
+            template,
+            args.job_params if args.job_params else None,
+            Path(os.path.abspath(template_file.parent)),
+            Path(os.getcwd()),
+        )
     except RuntimeError as rte:
         raise RuntimeError(f"ERROR generating Job: {str(rte)}")
     except DecodeValidationError as dve:
         raise RuntimeError(f"ERROR validating template: {str(dve)}")
-    return sample_job
 
 
 @dataclass

--- a/src/openjd/cli/_common/_job_from_template.py
+++ b/src/openjd/cli/_common/_job_from_template.py
@@ -159,7 +159,12 @@ def get_task_params(arguments: list[list[str]]) -> list[dict[str, str]]:
     return all_parameter_sets
 
 
-def job_from_template(template: JobTemplate, parameter_args: list[str] | None = None) -> Job:
+def job_from_template(
+    template: JobTemplate,
+    parameter_args: list[str] | None,
+    job_template_dir: Path,
+    current_working_dir: Path,
+) -> Job:
     """
     Given a decoded Job Template and a user-inputted parameter dictionary,
     generates a Job object.
@@ -170,7 +175,10 @@ def job_from_template(template: JobTemplate, parameter_args: list[str] | None = 
 
     try:
         parameter_values = preprocess_job_parameters(
-            job_template=template, job_parameter_values=parameter_dict
+            job_template=template,
+            job_parameter_values=parameter_dict,
+            job_template_dir=job_template_dir,
+            current_working_dir=current_working_dir,
         )
     except ValueError as ve:
         raise RuntimeError(f"Parameters can't be used with Template: {str(ve)}")

--- a/src/openjd/cli/_run/_local_session/_session_manager.py
+++ b/src/openjd/cli/_run/_local_session/_session_manager.py
@@ -23,7 +23,6 @@ from openjd.sessions import (
     ActionState,
     ActionStatus,
     Parameter,
-    ParameterType,
     Session,
     SessionState,
     PathMappingRule,
@@ -70,7 +69,7 @@ class LocalSession:
         # Evaluate Job parameters, if applicable
         if job.parameters:
             parameters_as_list = [
-                Parameter(type=ParameterType(param.type.name), name=name, value=param.value)
+                Parameter(type=ParameterValueType(param.type.name), name=name, value=param.value)
                 for (name, param) in job.parameters.items()
             ]
 
@@ -170,7 +169,7 @@ class LocalSession:
                             step=dep,
                             parameters=[
                                 Parameter(
-                                    type=ParameterType(param.type.name),
+                                    type=param.type,
                                     name=name,
                                     value=param.value,
                                 )
@@ -185,9 +184,9 @@ class LocalSession:
 
         else:
             if not task_parameter_values:
-                parameter_sets = [
-                    param_set for param_set in StepParameterSpaceIterator(space=step.parameterSpace)
-                ]
+                parameter_sets: list[TaskParameterSet] = list(
+                    StepParameterSpaceIterator(space=step.parameterSpace)
+                )
             else:
                 try:
                     parameter_sets = [
@@ -217,7 +216,7 @@ class LocalSession:
                         step=step,
                         parameters=[
                             Parameter(
-                                type=ParameterType(param.type.name),
+                                type=param.type,
                                 name=name,
                                 value=param.value,
                             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The breaking change in https://github.com/OpenJobDescription/openjd-model-for-python/pull/39
requires an update to openjd-cli

### What was the solution? (How)

Update the `openjd run` command to pass the required directories to preprocess_job_parameters.

### What is the impact of this change?

The CLI will work once both the model and this change are merged.

### How was this change tested?

Updated the unit tests and verified they run. Note I had to increase the timeout from 30 to 60 seconds, seems like running a session is slower on Windows.

I ran a job with both a template path parameter relative path default and a CLI parameter relative path, and confirmed that it works now, compared to before this breaking change when it failed.

### Was this change documented?

No

### Is this a breaking change?

Yes

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*