### PR TITLE
feat: support environment templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,37 @@
-## Open Job Description CLI
+## Open Job Description - CLI
 
-This CLI enables interactive support for writing Job templates using the Open Job Description specification.
+Open Job Description (OpenJD) is a flexible open specification for defining render jobs which are portable
+between studios and render solutions. This package provides a command-line interface that can be used
+to: Verifiy that OpenJD templates are syntactically correct; Run OpenJD jobs locally; and more.
+
+For more information about Open Job Description and our goals with it, please see the
+Open Job Description [Wiki on GitHub](https://github.com/OpenJobDescription/openjd-specifications/wiki).
+
+## Compatibility
+
+This library requires:
+
+1. Python 3.9 or higher;
+2. Linux, MacOS, or Windows operating system;
+3. On Linux/MacOS:
+    * `sudo`
+4. On Windows:
+    * PowerShell 7+
+
+## Versioning
+
+This package's version follows [Semantic Versioning 2.0](https://semver.org/).
+
+1. The MAJOR version is currently 0.
+2. The MINOR version is incremented when backwards incompatible changes are introduced to the public API.
+3. The PATCH version is incremented when bug fixes or backwards compatible changes are introduced to the public API.
 
 ## Commands
+
+### Getting Help
+
+The main `openjd` command and all subcommands support a `--help` option to display
+information on how to use the command.
 
 ### `check`
 Reports any syntax errors that appear in the schema of a Job Template file.
@@ -11,12 +40,12 @@ Reports any syntax errors that appear in the schema of a Job Template file.
 
 |Name|Type|Required|Description|Example|
 |---|---|---|---|---|
-|`path`|path|yes|A path leading to a Job template file, or a bundle containing a `.template.json`/`.template.yaml`/`.template.yml` file.|`/path/to/job.template.json`|
+|`path`|path|yes|A path leading to a Job or Environment template file.|`/path/to/template.json`|
 |`--output`|string|no|How to display the results of the command. Allowed values are `human-readable` (default), `json`, and `yaml`.|`--output json`, `--output yaml`|
 
 #### Example
 ```sh
-$ openjd-cli check /path/to/job.template.json
+$ openjd check /path/to/job.template.json
 
 Template at '/path/to/job.template.json' passes validation checks!
 ```
@@ -28,7 +57,7 @@ Displays summary information about a sample Job or a Step therein. The user may 
 
 |Name|Type|Required|Description|Example|
 |---|---|---|---|---|
-|`path`|path|yes|A path leading to a Job template file, or a bundle containing a `.template.json`/`.template.yaml`/`.template.yml` file.|`/path/to/job.template.json`|
+|`path`|path|yes|A path leading to a Job template file.|`/path/to/job.template.json`|
 |`--job-param`, `-p`|string, path|no|A key-value pair representing a parameter in the template and the value to use for it, provided as a string or a path to a JSON/YAML document prefixed with 'file://'. Can be specified multiple times.|`--job-param MyParam=5`, `-p file://parameter_file.json`|
 |`--step-name`|string|no|The name of the Step to summarize.|`--step-name Step1`|
 |`--output`|string|no|How to display the results of the command. Allowed values are `human-readable` (default), `json`, and `yaml`.|`--output json`, `--output yaml`|
@@ -63,14 +92,20 @@ Total environments: 0
 ```
 
 ### `run`
-Runs a sample Session on the user’s local machine. The user should provide the Step to run Tasks from, along with any desired Job or Task parameters.
+
+Given a Job Template, Job Parameters, and optional Environment Templates this will run a set of the Tasks
+from the constructed Job locally within an OpenJD Sesssion.
+
+Please see [How Jobs Are Run](https://github.com/OpenJobDescription/openjd-specifications/wiki/How-Jobs-Are-Run) for
+details on how Open Job Description's Jobs are run within Sessions.
 
 #### Arguments
 
 |Name|Type|Required|Description|Example|
 |---|---|---|---|---|
-|`path`|path|yes|A path leading to a Job template file, or a bundle containing a `.template.json`/`.template.yaml`/`.template.yml` file.|`/path/to/job.template.json`|
+|`path`|path|yes|A path leading to a Job template file.|`/path/to/job.template.json`|
 |`--step-name`|string|yes|The name of the Step to run in a local Session.|`--step-name Step1`|
+|`--environment`|paths|no|Path to a file containing Environment Template definitions. Can be provided multiple times.|`--environment /path/to/env.template1.json --environment /path/to/env.template2.yaml`|
 |`--job-param`, `-p`|string, path|no|A key-value pair representing a parameter in the template and the value to use for it, provided as a string or a path to a JSON/YAML document prefixed with 'file://'. Can be specified multiple times.|`--job-param MyParam=5`, `-p file://parameter_file.json`|
 |`--task-params`, `-tp`|string, path|no|A list of key-value pairs representing a Task parameter set for the Step, provided as a string or a path to a JSON/YAML document prefixed with 'file://'. If present, the Session will run one Task per parameter set supplied with `--task-params`. Can be specified multiple times.|`--task-params PingCount=20 PingDelay=30`, `-tp file://parameter_set_file.json`|
 |`--maximum-tasks`|integer|no|A maximum number of Tasks to run from this Step. Unless present, the Session will run all Tasks defined in the Step's parameter space, or one Task per `--task-params` argument.|`--maximum-tasks 5`|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,26 @@ dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.9"
-
+description = "Provides a command-line interface for working with Open Job Description templates."
+# https://pypi.org/classifiers/
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: MacOS",
+  "License :: OSI Approved :: Apache Software License",
+  "Intended Audience :: Developers",
+  "Intended Audience :: End Users/Desktop"
+]
 dependencies = [
-  "openjd-sessions == 0.3.*"
+  "openjd-sessions == 0.3.*",
+  "openjd-model == 0.2.*"
 ]
 
 [project.scripts]
@@ -142,3 +159,6 @@ source = [
 [tool.coverage.report]
 show_missing = true
 fail_under = 92
+omit= [
+  "src/openjd/cli/_version.py"
+]

--- a/src/openjd/cli/_check/_check_command.py
+++ b/src/openjd/cli/_check/_check_command.py
@@ -1,6 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from argparse import Namespace
+from openjd.model import (
+    DecodeValidationError,
+    SchemaVersion,
+    decode_job_template,
+    decode_environment_template,
+)
 
 from .._common import read_template, OpenJDCliResult, print_cli_result
 
@@ -11,10 +17,36 @@ def do_check(args: Namespace) -> OpenJDCliResult:
 
     try:
         # Raises: RuntimeError
-        filepath, _ = read_template(args)
+        template_object = read_template(args.path)
+
+        # Raises: KeyError
+        document_version = template_object["specificationVersion"]
+
+        # Raises: ValueError
+        template_version = SchemaVersion(document_version)
+
+        # Raises: DecodeValidationError
+        if SchemaVersion.is_job_template(template_version):
+            decode_job_template(template=template_object)
+        elif SchemaVersion.is_environment_template(template_version):
+            decode_environment_template(template=template_object)
+        else:
+            return OpenJDCliResult(
+                status="error",
+                message=f"Unknown template 'specificationVersion' ({document_version}).",
+            )
+
+    except KeyError:
+        return OpenJDCliResult(
+            status="error", message="ERROR: Missing field 'specificationVersion'"
+        )
     except RuntimeError as exc:
         return OpenJDCliResult(status="error", message=f"ERROR: {str(exc)}")
+    except DecodeValidationError as exc:
+        return OpenJDCliResult(
+            status="error", message=f"ERROR: '{str(args.path)}' failed checks: {str(exc)}"
+        )
 
     return OpenJDCliResult(
-        status="success", message=f"Template at '{str(filepath)}' passes validation checks."
+        status="success", message=f"Template at '{str(args.path)}' passes validation checks."
     )

--- a/src/openjd/cli/_common/__init__.py
+++ b/src/openjd/cli/_common/__init__.py
@@ -14,7 +14,12 @@ from ._job_from_template import (
     get_job_params,
     get_task_params,
 )
-from ._validation_utils import get_doc_type, read_template
+from ._validation_utils import (
+    get_doc_type,
+    read_template,
+    read_job_template,
+    read_environment_template,
+)
 from openjd.model import DecodeValidationError, Job
 
 __all__ = [
@@ -22,6 +27,8 @@ __all__ = [
     "get_job_params",
     "get_task_params",
     "read_template",
+    "read_job_template",
+    "read_environment_template",
     "validate_task_parameters",
 ]
 
@@ -61,7 +68,7 @@ def add_common_arguments(
             "path",
             type=Path,
             action="store",
-            help="The path to the template file or Job Bundle to use.",
+            help="The path to the template file.",
         )
     if CommonArgument.JOB_PARAMS in common_arg_options:
         parser.add_argument(
@@ -101,12 +108,12 @@ class SubparserGroup:
 def generate_job(args: Namespace) -> Job:
     try:
         # Raises: RuntimeError, DecodeValidationError
-        template_file, template = read_template(args)
+        template = read_job_template(args.path)
         # Raises: RuntimeError
         return job_from_template(
             template,
             args.job_params if args.job_params else None,
-            Path(os.path.abspath(template_file.parent)),
+            Path(os.path.abspath(args.path.parent)),
             Path(os.getcwd()),
         )
     except RuntimeError as rte:

--- a/test/openjd/cli/__init__.py
+++ b/test/openjd/cli/__init__.py
@@ -16,7 +16,14 @@ MOCK_TEMPLATE = {
             # Basic step; uses Job parameters and has an environment
             "name": "NormalStep",
             "script": {"actions": {"onRun": {"command": "echo", "args": ["{{Param.Message}}"]}}},
-            "stepEnvironments": [{"name": "env1", "variables": {"var1": "val1"}}],
+            "stepEnvironments": [
+                {
+                    "name": "env1",
+                    "script": {
+                        "actions": {"onEnter": {"command": "echo", "args": ["EnteringEnv"]}}
+                    },
+                }
+            ],
         },
         {
             # Step that will wait for one minute before completing its Task

--- a/test/openjd/cli/conftest.py
+++ b/test/openjd/cli/conftest.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from . import MOCK_TEMPLATE, SampleSteps
 from openjd.cli._common._job_from_template import job_from_template
 from openjd.cli._run._local_session._session_manager import LocalSession
-from openjd.model import decode_template
+from openjd.model import decode_job_template
 
 
 @pytest.fixture(scope="function", params=[[], ["Message='A new message!'"]])
@@ -27,7 +27,7 @@ def sample_job_and_dirs(request):
         os.makedirs(template_dir)
         os.makedirs(current_working_dir)
 
-        template = decode_template(template=MOCK_TEMPLATE)
+        template = decode_job_template(template=MOCK_TEMPLATE)
         yield (
             job_from_template(
                 template=template,

--- a/test/openjd/cli/test_check_command.py
+++ b/test/openjd/cli/test_check_command.py
@@ -36,26 +36,6 @@ def test_do_check_file_success(tempfile_extension: str, doc_serializer: Callable
     Path(temp_template.name).unlink()
 
 
-def test_do_check_bundle_success():
-    """
-    The CLI should be able to find a template JSON/YAML document in a provided directory
-    """
-    temp_template = None
-
-    with tempfile.TemporaryDirectory() as temp_bundle:
-        with tempfile.NamedTemporaryFile(
-            mode="w+t",
-            suffix=".template.json",
-            encoding="utf8",
-            delete=False,
-            dir=temp_bundle,
-        ) as temp_template:
-            json.dump(MOCK_TEMPLATE, temp_template.file)
-
-        mock_args = Namespace(path=Path(temp_bundle), output="human-readable")
-        do_check(mock_args)
-
-
 def test_do_check_file_error():
     """
     Raise a SystemExit on an error

--- a/test/openjd/cli/test_schema_command.py
+++ b/test/openjd/cli/test_schema_command.py
@@ -78,6 +78,28 @@ def test_do_get_schema_success(capsys: pytest.CaptureFixture):
 
 
 @pytest.mark.usefixtures("capsys")
+def test_do_get_schema_success_environment(capsys: pytest.CaptureFixture):
+    """
+    Test that the `schema` command returns a correctly-formed
+    JSON body with specific Environment template attributes.
+    """
+    with patch(
+        "openjd.cli._schema._schema_command._process_regex", new=Mock(side_effect=_process_regex)
+    ) as patched_process_regex:
+        do_get_schema(
+            Namespace(version=SchemaVersion.ENVIRONMENT_v2023_09, output="human-readable")
+        )
+        patched_process_regex.assert_called()
+
+    model_output = capsys.readouterr().out
+    model_json = json.loads(model_output)
+
+    assert model_json is not None
+    assert model_json["title"] == "EnvironmentTemplate"
+    assert "specificationVersion" in model_json["properties"]
+
+
+@pytest.mark.usefixtures("capsys")
 def test_do_get_schema_incorrect_version(capsys: pytest.CaptureFixture):
     """
     Test that the `schema` command fails if an unsupported version string


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

Environment Templates are a part of the spec that allows an Environment to be defined outside of a Job Template, but still be applied when running Job(s) created from the Job Template. The CLI doesn't support these yet.

### What was the solution? (How)

This commit teaches the CLI about environment templates:
1. In the 'check' command, to verify a template syntax;
2. In the 'schema' command, to generate json schema for EnvironmentTemplates; and
3. In the 'run' command, to apply Environments when running a Job locally.

The implementation of this also applies a few small cleanups and refactors to make the implementation more straightforward.

There's also a bit of cleanup around "bundles" (not a thing) and the README.

### What is the impact of this change?

The CLI understands what Environment Templates are, and lets the end-user work with them.

### How was this change tested?

I've run tests locally just by running the CLI, and I've enhanced the unit tests to cover the functionality. I've also modified a couple of tests to no longer look for mocked calls but to, instead, actually run code and look at the results to determine whether it's functioning correctly or not.

### Was this change documented?

Yes, I modified the README to cover the new CLI options.

### Is this a breaking change?

No, all added CLI options are 100% optional.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*