### PR TITLE
chore(release): fix release workflow

### DIFF
--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -4,17 +4,17 @@ This script gets the changelog notes for the latest version of this package. It 
 1. A file called CHANGELOG.md is in the current directory that has the changelog
 2. The changelog file is formatted in a way such that level 2 headers are:
     a. The only indication of the beginning of a version's changelog notes.
-    b. Always begin with `## v` (i.e. v1.2.3)
+    b. Always begin with `## `
 3. The changelog file contains the newest version's changelog notes at the top of the file.
 
 Example CHANGELOG.md:
 ```
-## v1.0.0 (2024-02-06)
+## 1.0.0 (2024-02-06)
 
 ### BREAKING CHANGES
 * **api**: rename all APIs
 
-## v0.1.0 (2024-02-06)
+## 0.1.0 (2024-02-06)
 
 ### Features
 * **api**: add new api
@@ -22,7 +22,7 @@ Example CHANGELOG.md:
 
 Running this script on the above CHANGELOG.md should return the following contents:
 ```
-## v1.0.0 (2024-02-06)
+## 1.0.0 (2024-02-06)
 
 ### BREAKING CHANGES
 * **api**: rename all APIs
@@ -31,7 +31,7 @@ Running this script on the above CHANGELOG.md should return the following conten
 """
 import re
 
-h2 = r"^##\sv.*$"
+h2 = r"^##\s.*$"
 with open("CHANGELOG.md") as f:
     contents = f.read()
 matches = re.findall(h2, contents, re.MULTILINE)

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,7 +2,7 @@ name: Code Quality
 
 on:
   pull_request:
-    branches: [ mainline ]
+    branches: [ mainline, release ]
   workflow_call:
     inputs:
       branch:

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -13,6 +13,9 @@ on:
         - minor
         - major
 
+concurrency:
+  group: release
+
 jobs:
   TestMainline:
     name: Test Mainline
@@ -24,6 +27,7 @@ jobs:
   Bump:
     needs: TestMainline
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       pull-requests: write
@@ -42,7 +46,7 @@ jobs:
 
       - name: ConfigureGit
         run: |
-          git config --local user.email "client-software-ci@amazon.com"
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
 
       - name: MergePushRelease
@@ -58,6 +62,7 @@ jobs:
           fi
 
           # Backup actual changelog to preserve its contents
+          touch CHANGELOG.md
           cp CHANGELOG.md CHANGELOG.bak.md
 
           # Run semantic-release to generate new changelog

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - CHANGELOG.md
 
+concurrency:
+  group: release
+
 jobs:
   VerifyCommit:
     runs-on: ubuntu-latest
@@ -22,7 +25,7 @@ jobs:
 
       - name: VerifyAuthor
         run: |
-          EXPECTED_AUTHOR="client-software-ci@amazon.com"
+          EXPECTED_AUTHOR="129794699+client-software-ci@users.noreply.github.com"
           AUTHOR=$(git show -s --format='%ae' HEAD)
           if [[ $AUTHOR != $EXPECTED_AUTHOR ]]; then
             echo "ERROR: Expected author email to be '$EXPECTED_AUTHOR', but got '$AUTHOR'. Aborting release."
@@ -34,8 +37,15 @@ jobs:
   Release:
     needs: VerifyCommit
     runs-on: ubuntu-latest
+    environment: release
     permissions:
+      id-token: write
       contents: write
+    env:
+      CODEARTIFACT_REGION: "us-west-2"
+      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -65,9 +75,9 @@ jobs:
           NEXT_SEMVER=$(python -c 'import sys, re; print(re.match(r"chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*", sys.argv[1]).group(1))' "$COMMIT_TITLE")
 
           # The format of the tag must match the pattern in pyproject.toml -> tool.semantic_release.tag_format
-          TAG="v$NEXT_SEMVER"
+          TAG="$NEXT_SEMVER"
 
-          git config --local user.email "client-software-ci@amazon.com"
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
 
           git tag -a $TAG -m "Release $TAG"
@@ -80,9 +90,17 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
+          export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
           pip install --upgrade hatch
           hatch build
 
@@ -96,6 +114,7 @@ jobs:
   MergeBack:
     needs: Release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:
@@ -104,6 +123,7 @@ jobs:
         with:
           ref: mainline
           fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
 
       - name: MergeBackMainline
         run: |
@@ -128,7 +148,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.Release.outputs.tag }}
+          ref: release
           fetch-depth: 0
 
       - name: Configure AWS credentials
@@ -145,6 +165,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
           pip install --upgrade hatch
           pip install --upgrade twine
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -33,8 +33,9 @@ build = "hatch build"
 PIP_INDEX_URL=""
 
 [envs.release]
-pre-install-commands = [
-  "pip install -r requirements-release.txt"
+detached = true
+dependencies = [
+  "python-semantic-release == 8.7.*"
 ]
 
 [envs.release.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ omit= [
 [tool.semantic_release]
 # Can be removed or set to true once we are v1
 major_on_zero = false
-tag_format = "v{version}"
+tag_format = "{version}"
 
 [tool.semantic_release.publish]
 upload_to_vcs_release = false

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,3 @@
+# HACK: This file solely exists for dependabot checks. The actual dependencies are in `hatch.toml` in the `release` environment.
+# If dependabot opens a PR that modifies this file, please make sure to update the coresponding dependency in `hatch.toml` as well.
 python-semantic-release == 8.7.*


### PR DESCRIPTION
Copy release workflow fixes  from https://github.com/OpenJobDescription/openjd-model-for-python/compare/1eaba41d66054ddb58c067b47c605c4ab1f9b837...d5909d656b5dd2c6c39aec9c73bf7bac585d4c66

Verification checklist:
- [x] The `CI_TOKEN` secret is moved into the `release` environment and deleted from repo-level secrets
- [x] The `release` environment has a protection rule for required reviewers set to the developer group
- [x] The CI account can push directly to `mainline` without PR
- [x] The CI account can push directly to `release` without PR

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*