### PR TITLE
chore(release): sign GitHub release artifacts with gpg

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Import PGP Key
         run: |
-          SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
+          export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
           printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
 
           PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
@@ -125,7 +125,7 @@ jobs:
           for file in dist/*; do
             printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "Open Job Description" --passphrase-fd 0 --output $file.sig --detach-sign $file
             echo "Created signature file for $file"
-          fi
+          done
 
       - name: PushRelease
         env:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to sign our GitHub release artifacts with `gpg` so that users can verify their downloads

### What was the solution? (How)
Sign our GitHub release artifacts with `gpg` in our `Release: Publish` workflow and distribute the PGP signature files on the GitHub release page

### What is the impact of this change?
Users can verify their downloads using our PGP signature files and public key

### How was this change tested?
Verified this is working on my test repository (ping me for access if you don't have it)
- https://github.com/jericht/GitHubWorkflowPlayground/compare/3e5ec08cef9c962e8b0ebd5f4a6be84fcdbab0ec...6007ae76da1abcea5a356d2657c813a7b9de080e
- https://github.com/jericht/GitHubWorkflowPlayground/actions/runs/7859081504/job/21444784159
- https://github.com/jericht/GitHubWorkflowPlayground/releases/tag/0.3.0

Verified changing to `printenv` is working:
- https://github.com/jericht/GitHubWorkflowPlayground/actions/runs/7876309027/job/21490055464

**PRE-MERGE CHECKLIST**
- [x] The `AWS_PGP_KEY_SECRET_ROLE` secret has been added to the `release` environment
- [x] The `AWS_PGP_KEY_SECRET` secret has been added to the `release` environment
- [x] Add `mainline` as a branch allowed to use `release` environment


### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*