### PR TITLE
feat!: public release

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -41,11 +41,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    env:
-      CODEARTIFACT_REGION: "us-west-2"
-      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,17 +85,9 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
           pip install --upgrade hatch
           hatch build
 
@@ -174,13 +161,6 @@ jobs:
           ref: release
           fetch-depth: 0
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -188,14 +168,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
           pip install --upgrade hatch
           pip install --upgrade twine
 
       - name: Build
         run: hatch build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
 
       - name: Publish to Repository
         run: |

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -22,10 +22,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     env:
       PYTHON: ${{ matrix.python-version }}
-      CODEARTIFACT_REGION: "us-west-2"
-      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v4
       if: ${{ !inputs.branch }}
@@ -40,27 +36,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-        aws-region: us-west-2
-        mask-aws-account-id: true
-
-    - name: CodeArtifact Setup Windows
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: |
-        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
-
-    - name: CodeArtifact Setup Linux/MacOS
-      if: ${{ matrix.os != 'windows-latest' }}
-      run: |
-        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
 
     - name: Install Dependencies
       run: pip install --upgrade -r requirements-development.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Open Job Description - CLI
 
+[![pypi](https://img.shields.io/pypi/v/openjd-cli.svg)](https://pypi.python.org/pypi/openjd-cli)
+
 Open Job Description (OpenJD) is a flexible open specification for defining render jobs which are portable
 between studios and render solutions. This package provides a command-line interface that can be used
 to validate OpenJD templates, run OpenJD jobs locally, and more.
@@ -16,7 +18,12 @@ This library requires:
 3. On Linux/MacOS:
     * `sudo`
 4. On Windows:
-    * PowerShell 7+
+    * PowerShell 5.x
+
+**EXPERIMENTAL** Note that compatibility with the Windows operating system is currently in active development
+and should be considered to be experimental. We recommend that this application not be used in Windows-based
+production environments at this time. We will remove this notice when Windows compatibility is considered
+sufficiently stable and secure for use in Windows-based production environments.
 
 ## Versioning
 
@@ -27,6 +34,13 @@ versions will increment during this initial development stage, they are describe
 1. The MAJOR version is currently 0, indicating initial development. 
 2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
 3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
+
+## Contributing
+
+We encourage all contributions to this package.  Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for our contributing guidelines.
 
 ## Commands
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -23,14 +23,8 @@ lint = [
 [[envs.all.matrix]]
 python = ["3.9", "3.10", "3.11"]
 
-[envs.default.env-vars]
-PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
-
 [envs.codebuild.scripts]
 build = "hatch build"
-
-[envs.codebuild.env-vars]
-PIP_INDEX_URL=""
 
 [envs.release]
 detached = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,14 @@ classifiers = [
   "Intended Audience :: End Users/Desktop"
 ]
 dependencies = [
-  "openjd-sessions == 0.4.*",
-  "openjd-model == 0.3.*"
+  "openjd-sessions == 0.5.*",
+  "openjd-model == 0.4.*"
 ]
+
+[project.urls]
+Homepage = "https://github.com/OpenJobDescription/openjd-cli"
+Source = "https://github.com/OpenJobDescription/openjd-cli"
+
 
 [project.scripts]
 openjd = "openjd:__main__.main"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We're about to publicly release this library. We need to prep the build process for that.

### What was the solution? (How)

- Update the build script to no longer define a PIP_INDEX_URL -- the environment variable
  that we used to interface with our internal repository during private development.
- Update the code quality check to pull deps from the public PyPI, so
  that we're testing as customers would use it.
- Use the public PyPI in the release flows since all deps are now
  available publicly. This ensures that the artifact we release can be
  built & used by anyone using PyPI.
- Increment the openjd-model and openjd-sessions dependencies to the
  first publicly available versions.
- Small additions to the README.

### What is the impact of this change?

Release readiness

### How was this change tested?

Just building the hatch environment.

### Was this change documented?

Yes, it is documentation as well.

### Is this a breaking change?

No, but it is being marked as one to force a minor version bump when we release.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*