### PR TITLE
chore: update dependencies on openjd packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
   "Intended Audience :: End Users/Desktop"
 ]
 dependencies = [
-  "openjd-sessions == 0.3.*",
-  "openjd-model == 0.2.*"
+  "openjd-sessions == 0.4.*",
+  "openjd-model == 0.3.*"
 ]
 
 [project.scripts]

--- a/src/openjd/cli/_check/_check_command.py
+++ b/src/openjd/cli/_check/_check_command.py
@@ -3,7 +3,7 @@
 from argparse import Namespace
 from openjd.model import (
     DecodeValidationError,
-    SchemaVersion,
+    TemplateSpecificationVersion,
     decode_job_template,
     decode_environment_template,
 )
@@ -23,12 +23,12 @@ def do_check(args: Namespace) -> OpenJDCliResult:
         document_version = template_object["specificationVersion"]
 
         # Raises: ValueError
-        template_version = SchemaVersion(document_version)
+        template_version = TemplateSpecificationVersion(document_version)
 
         # Raises: DecodeValidationError
-        if SchemaVersion.is_job_template(template_version):
+        if TemplateSpecificationVersion.is_job_template(template_version):
             decode_job_template(template=template_object)
-        elif SchemaVersion.is_environment_template(template_version):
+        elif TemplateSpecificationVersion.is_environment_template(template_version):
             decode_environment_template(template=template_object)
         else:
             return OpenJDCliResult(

--- a/src/openjd/cli/_run/_local_session/_actions.py
+++ b/src/openjd/cli/_run/_local_session/_actions.py
@@ -1,8 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from openjd.model import Step
+from openjd.model import Step, TaskParameterSet
 from openjd.model.v2023_09 import Environment
-from openjd.sessions import Parameter, Session
+from openjd.sessions import Session
 
 
 class SessionAction:
@@ -21,9 +21,9 @@ class SessionAction:
 
 class RunTaskAction(SessionAction):
     _step: Step
-    _parameters: list[Parameter]
+    _parameters: TaskParameterSet
 
-    def __init__(self, session: Session, step: Step, parameters: list[Parameter]):
+    def __init__(self, session: Session, step: Step, parameters: TaskParameterSet):
         super(RunTaskAction, self).__init__(session)
         self._step = step
         self._parameters = parameters
@@ -34,7 +34,8 @@ class RunTaskAction(SessionAction):
         )
 
     def __str__(self):
-        return f"Run Step '{self._step.name}' with Task parameters '{[parameter.value for parameter in self._parameters]}'"
+        parameters = {name: parameter.value for name, parameter in self._parameters.items()}
+        return f"Run Step '{self._step.name}' with Task parameters '{str(parameters)}'"
 
 
 class EnterEnvironmentAction(SessionAction):

--- a/src/openjd/cli/_run/_run_command.py
+++ b/src/openjd/cli/_run/_run_command.py
@@ -415,7 +415,6 @@ def do_run(args: Namespace) -> OpenJDCliResult:
         elif args.tasks:
             task_params = _process_tasks(args.tasks)
 
-        print(step_map[args.step])
         _validate_task_params(step_map[args.step], task_params)
 
     except RuntimeError as rte:

--- a/src/openjd/cli/_schema/_schema_command.py
+++ b/src/openjd/cli/_schema/_schema_command.py
@@ -5,19 +5,20 @@ import json
 from typing import Union
 
 from .._common import OpenJDCliResult, print_cli_result
-from openjd.model import SchemaVersion, JobTemplate, EnvironmentTemplate
+from openjd.model import EnvironmentTemplate, JobTemplate, TemplateSpecificationVersion
 
 
 def add_schema_arguments(schema_parser: ArgumentParser) -> None:
     allowed_values = [
         v.value
-        for v in SchemaVersion
-        if SchemaVersion.is_job_template(v) or SchemaVersion.is_environment_template(v)
+        for v in TemplateSpecificationVersion
+        if TemplateSpecificationVersion.is_job_template(v)
+        or TemplateSpecificationVersion.is_environment_template(v)
     ]
     schema_parser.add_argument(
         "--version",
         action="store",
-        type=SchemaVersion,
+        type=TemplateSpecificationVersion,
         required=True,
         help=f"The specification version to return a JSON schema document for. Allowed values: {', '.join(allowed_values)}",
     )
@@ -46,9 +47,9 @@ def do_get_schema(args: Namespace) -> OpenJDCliResult:
     """
 
     Template: Union[type[JobTemplate], type[EnvironmentTemplate]]
-    if args.version == SchemaVersion.v2023_09:
+    if args.version == TemplateSpecificationVersion.JOBTEMPLATE_v2023_09:
         from openjd.model.v2023_09 import JobTemplate as Template
-    elif args.version == SchemaVersion.ENVIRONMENT_v2023_09:
+    elif args.version == TemplateSpecificationVersion.ENVIRONMENT_v2023_09:
         from openjd.model.v2023_09 import EnvironmentTemplate as Template
     else:
         return OpenJDCliResult(

--- a/test/openjd/cli/test_schema_command.py
+++ b/test/openjd/cli/test_schema_command.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from openjd.cli._schema._schema_command import do_get_schema, _process_regex
-from openjd.model import SchemaVersion
+from openjd.model import TemplateSpecificationVersion
 from pydantic import BaseModel
 
 from argparse import Namespace
@@ -64,7 +64,12 @@ def test_do_get_schema_success(capsys: pytest.CaptureFixture):
     with patch(
         "openjd.cli._schema._schema_command._process_regex", new=Mock(side_effect=_process_regex)
     ) as patched_process_regex:
-        do_get_schema(Namespace(version=SchemaVersion.v2023_09, output="human-readable"))
+        do_get_schema(
+            Namespace(
+                version=TemplateSpecificationVersion.JOBTEMPLATE_v2023_09.value,
+                output="human-readable",
+            )
+        )
         patched_process_regex.assert_called()
 
     model_output = capsys.readouterr().out
@@ -87,7 +92,10 @@ def test_do_get_schema_success_environment(capsys: pytest.CaptureFixture):
         "openjd.cli._schema._schema_command._process_regex", new=Mock(side_effect=_process_regex)
     ) as patched_process_regex:
         do_get_schema(
-            Namespace(version=SchemaVersion.ENVIRONMENT_v2023_09, output="human-readable")
+            Namespace(
+                version=TemplateSpecificationVersion.ENVIRONMENT_v2023_09.value,
+                output="human-readable",
+            )
         )
         patched_process_regex.assert_called()
 
@@ -124,7 +132,12 @@ def test_do_get_schema_error(capsys: pytest.CaptureFixture):
         patch.object(BaseModel, "schema", side_effect=RuntimeError("Test error")),
         pytest.raises(SystemExit),
     ):
-        do_get_schema(Namespace(version=SchemaVersion.v2023_09, output="human-readable"))
+        do_get_schema(
+            Namespace(
+                version=TemplateSpecificationVersion.JOBTEMPLATE_v2023_09.value,
+                output="human-readable",
+            )
+        )
     output = capsys.readouterr().out
 
     assert "Test error" in output

--- a/test/openjd/test_main.py
+++ b/test/openjd/test_main.py
@@ -7,7 +7,7 @@ import pytest
 import sys
 
 from openjd import __main__
-from openjd.model import SchemaVersion
+from openjd.model import TemplateSpecificationVersion
 
 
 @patch("openjd.cli._check.do_check")
@@ -167,10 +167,10 @@ def test_cli_schema_success(mock_schema: Mock):
     """
 
     mock_schema.assert_not_called()
-    # "UNDEFINED" should always be a valid SchemaVersion option, even though the unpatched
+    # "UNDEFINED" should always be a valid TemplateSpecificationVersion option, even though the unpatched
     # `do_get_schema` function throws an error on receiving it
     with patch.object(
-        sys, "argv", new=(["openjd", "schema", "--version", SchemaVersion.UNDEFINED])
+        sys, "argv", new=(["openjd", "schema", "--version", TemplateSpecificationVersion.UNDEFINED])
     ):
         __main__.main()
         mock_schema.assert_called_once()


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

Newer versions of the openjd-model and openjd-sessions packages have been released. The changes include some quality-of-life improvements to template input validation, so we want to update the cli to have these changes.

### What was the solution? (How)

Update the dependencies, and apply the changes dictated by the breaking changes in both.

1. The `SchemaVersion` enum was removed from `openjd-model` in favour of `TemplateSpecificationVersion`
2. The `Parameter` type was removed from `openjd-sessions` in favour of the parameter types defined in `openjd-model`

### What is the impact of this change?

Better validation errors for customers.

### How was this change tested?

I ran the unit tests, and I've been running the cli with a couple of job templates.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*