### PR TITLE
fix: improve missing job parameter error for summary command

### DIFF
--- a/src/openjd/cli/_common/_job_from_template.py
+++ b/src/openjd/cli/_common/_job_from_template.py
@@ -124,7 +124,7 @@ def job_from_template(
             current_working_dir=current_working_dir,
         )
     except ValueError as ve:
-        raise RuntimeError(f"Parameters can't be used with Template: {str(ve)}")
+        raise RuntimeError(str(ve))
 
     try:
         return create_job(job_template=template, job_parameter_values=parameter_values)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The error message that one gets when using the summary command on a job template that has job parameters with no default value is a tad confusing. It looks like:

```
ERROR generating Job: Parameters can't be used with Template: Values missing for required job parameters: NumAnimationFrames, OutputDirectory, RenderScript
```

The "Parameters can't be used with Template" part is leading to confusion.

### What was the solution? (How)

Remove the problematic phase from the error. The error comes from trying to preprocess_job_parameters(), and that function already has decent error messaging.

### What is the impact of this change?

An error message that is more actionable.

### How was this change tested?

Just running the `openjd summary` command locally.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*