### PR TITLE
chore: backfill CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+## 0.3.0 (2024-02-12)
+
+### BREAKING CHANGES
+* modifying how tasks are selected in run command (#37) ([`59c41d9`](https://github.com/OpenJobDescription/openjd-cli/commit/59c41d90eda95e666e49c37d1fdfe0d570742b32))
+* Update openjd-cli to pass template_dir/cwd to preprocess_job_parameters (#29) ([`0983e1d`](https://github.com/OpenJobDescription/openjd-cli/commit/0983e1d0e3cece60ef825ec2d1b86dc20f2da22d))
+
+### Features
+* Allow job parameters as JSON string (#34) ([`8708b2c`](https://github.com/OpenJobDescription/openjd-cli/commit/8708b2ced5945465fd6706d95eac0bb1ac6317ca))
+* support environment templates (#30) ([`b845d70`](https://github.com/OpenJobDescription/openjd-cli/commit/b845d70944863c11c308b50669cbdf99d037eeb3))
+
+### Bug Fixes
+* improve missing job parameter error for summary command (#44) ([`975863a`](https://github.com/OpenJobDescription/openjd-cli/commit/975863a7097d536ca786561e0adec665bb0eec77))
+* Allow job parameter values to be empty strings. (#26) ([`b8959d0`](https://github.com/OpenJobDescription/openjd-cli/commit/b8959d077cc5cd4697f101ba3e45adceddb4ccac))
+
+## 0.2.0 (2023-11-06)
+
+### BREAKING CHANGES
+* accept path mapping rules as per schema (#16) ([`a9d71fd`](https://github.com/OpenJobDescription/openjd-cli/commit/a9d71fd0ddba50cda9a6edeec93ad1cf3ce67fbd))
+
+
+
+## 0.1.4 (2023-11-01)
+
+
+
+### Bug Fixes
+* add entrypoint to packaging (#14) ([`55cc90a`](https://github.com/OpenJobDescription/openjd-cli/commit/55cc90a58ec85271c4b84d392ddc627225a8bde9))
+
+## 0.1.3 (2023-10-27)
+
+
+
+
+## 0.1.1 (2023-09-14)
+
+
+
+### Bug Fixes
+* add back cli entrypoint (#8) ([`10188dd`](https://github.com/OpenJobDescription/openjd-cli/commit/10188ddf971dc51b043994858719fe91bbce8a68))
+
+## 0.1.0 (2023-09-12)
+
+
+
+


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)

We've set up scripting to generate a CHANGELOG, but we need to backfill the CHANGELOG with the previous versions' details. This does that.

### What was the solution? (How)

I ran the release bump command and then deleted the upcoming 0.3.0 changes from the generated changelog.

### What is the impact of this change?

Details on previously released versions are available in the changelog.

### How was this change tested?

N/A

### Was this change documented?

It is documentation.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*