### PR TITLE
chore(release): publish to PyPI

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -211,6 +211,10 @@ jobs:
           export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CUSTOMER_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
           twine upload dist/*
 
+      # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
   PublishToInternal:
     needs: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
### PRE-MERGE CHECKLIST
* [x] Configured "Trusted Publishing" for the corresponding PyPI repository (see https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi)

### What was the problem/requirement? (What/Why)
We need to publish to PyPI when we go public

### What was the solution? (How)
Publish to PyPI using `pypa/gh-action-pypi-publish` following https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

![image](https://github.com/OpenJobDescription/openjd-cli/assets/68654047/10f0d675-ddae-43cf-9015-3d55564e2ebc)


### What is the impact of this change?
The release workflow will now publish to PyPI

### How was this change tested?
In a test repo that published to Test PyPI: https://github.com/jericht/GitHubWorkflowPlayground/actions/runs/7879245195/job/21499159977

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*