### PR TITLE
fix: run command exits when an action reaches timeout

### DIFF
--- a/src/openjd/cli/_run/_local_session/_session_manager.py
+++ b/src/openjd/cli/_run/_local_session/_session_manager.py
@@ -376,7 +376,7 @@ class LocalSession:
             if isinstance(self._current_action, RunTaskAction):
                 self.tasks_run += 1
             self._action_ended.set()
-        if new_status.state in (ActionState.FAILED, ActionState.CANCELED):
+        if new_status.state in (ActionState.FAILED, ActionState.CANCELED, ActionState.TIMEOUT):
             self.failed = True
             self._action_ended.set()
 

--- a/test/openjd/cli/test_run_command.py
+++ b/test/openjd/cli/test_run_command.py
@@ -434,6 +434,39 @@ TEST_RUN_ENV_TEMPLATE_FAILS_EXIT = {
             True,
             id="EnvExitFails_2",
         ),
+        pytest.param(
+            {
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "TimeoutTest",
+                "parameterDefinitions": [{"name": "J", "type": "STRING"}],
+                "steps": [
+                    {
+                        "name": "Timeout",
+                        "script": {
+                            "actions": {
+                                "onRun": {
+                                    "command": "python",
+                                    "args": [
+                                        "-c",
+                                        # Obfuscate "EXIT_NORMAL" so it doesn't appear in the log when Windows prints the command that's run to the log.
+                                        "import time,sys; print('SLEEP'); sys.stdout.flush(); time.sleep(5); print(chr(69)+'XIT_NORMAL')",
+                                    ],
+                                    "timeout": 2,
+                                }
+                            }
+                        },
+                    }
+                ],
+            },
+            [],  # Env Templates
+            "Timeout",  # step name
+            [],  # Task params
+            False,  # run_dependencies
+            re.compile(r"SLEEP"),
+            "EXIT_NORMAL",
+            True,
+            id="TaskTimeout",
+        ),
     ],
 )
 def test_do_run_success(


### PR DESCRIPTION
Fixes: https://github.com/OpenJobDescription/openjd-cli/issues/96

### What was the problem/requirement? (What/Why)

 When using the run subcommand to run an action that reaches its timeout, the action is properly ended but the CLI itself does not exit. It's waiting in _run_local_session() for the session.ended event to be set, but it's not being set.

### What was the solution? (How)

 The LocalSession's _action_callback method was not handling the case where the returned ActionState was TIMEOUT. It now handles it.

### What is the impact of this change?

Users that use the run subcommand to test templates whose action(s) reach their timeout will now experience the CLI application properly exiting.

### How was this change tested?

Both manually by running the template in the bug report ticket and by adding a unit test that covers the case.

### Was this change documented?

N/A

### Is this a breaking change?

No. It's a fix that does not impact the public interfaces in any way.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*