### PR TITLE
feat: Update to use Pydantic V2 and enable chunking

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -21,7 +21,7 @@ lint = [
 ]
 
 [[envs.all.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [envs.codebuild.scripts]
 build = "hatch build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
   "Intended Audience :: End Users/Desktop"
 ]
 dependencies = [
-  "openjd-sessions == 0.9.*",
-  "openjd-model == 0.5.*"
+  "openjd-sessions == 0.10.*",
+  "openjd-model == 0.6.*"
 ]
 
 [project.urls]

--- a/src/openjd/cli/_check/_check_command.py
+++ b/src/openjd/cli/_check/_check_command.py
@@ -27,7 +27,7 @@ def do_check(args: Namespace) -> OpenJDCliResult:
 
         # Raises: DecodeValidationError
         if TemplateSpecificationVersion.is_job_template(template_version):
-            decode_job_template(template=template_object)
+            decode_job_template(template=template_object, supported_extensions=["TASK_CHUNKING"])
         elif TemplateSpecificationVersion.is_environment_template(template_version):
             decode_environment_template(template=template_object)
         else:

--- a/src/openjd/cli/_common/_validation_utils.py
+++ b/src/openjd/cli/_common/_validation_utils.py
@@ -62,7 +62,7 @@ def read_job_template(template_file: Path) -> JobTemplate:
     template_object = read_template(template_file)
 
     # Raises: DecodeValidationError
-    template = decode_job_template(template=template_object)
+    template = decode_job_template(template=template_object, supported_extensions=["TASK_CHUNKING"])
 
     return template
 

--- a/src/openjd/cli/_run/_run_command.py
+++ b/src/openjd/cli/_run/_run_command.py
@@ -69,9 +69,10 @@ def add_run_arguments(run_parser: ArgumentParser):
         dest="task_params",
         metavar="PARAM=VALUE",
         help=(
-            "This argument instructs the command to run a single task in a Session with the given value for one of the task parameters "
-            "defined for the Step. The option must be provided once for each task parameter defined for the Step, with each instance "
-            "providing the value for a different task parameter. Mutually exclusive with --tasks and --maximum-tasks."
+            "This argument instructs the command to run a single task or chunk of tasks in a Session with the given value for "
+            "one of the task parameters defined for the Step. The option must be provided once for each task parameter defined "
+            "for the Step, with each instance providing the value for a different task parameter. Mutually exclusive with "
+            "--tasks and --maximum-tasks."
         ),
     )
     group.add_argument(
@@ -81,9 +82,9 @@ def add_run_arguments(run_parser: ArgumentParser):
         dest="tasks",
         metavar='file://tasks.json OR file://tasks.yaml OR [{"Param": "Value1", ...}, {"Param": "Value2", ...}]',
         help=(
-            "This argument instructs the command to run one or more tasks for the Step in a Session. The argument must be either "
-            "the filename of a JSON or YAML file containing an array of maps from task parameter name to value; or an inlined "
-            "JSON string of the same. Mutually exclusive with --task-param/-tp and --maximum-tasks."
+            "This argument instructs the command to run one or more tasks/chunks of tasks for the Step in a Session. "
+            "The argument must be either the filename of a JSON or YAML file containing an array of maps from task parameter "
+            "name to value; or an inlined JSON string of the same. Mutually exclusive with --task-param/-tp and --maximum-tasks."
         ),
     )
     group.add_argument(
@@ -206,10 +207,8 @@ def _process_task_params(arguments: list[str]) -> dict[str, str]:
             )
 
     if error_list:
-        error_msg = "Found the following errors collecting Task parameters:"
-        for error in error_list:
-            error_msg += f"\n- {error}"
-        raise RuntimeError(error_msg)
+        error_msgs = "".join(f"\n - {error}" for error in error_list)
+        raise RuntimeError("Found the following errors collecting Task parameters:" + error_msgs)
 
     return parameter_set
 
@@ -278,8 +277,8 @@ def _validate_task_params(step: Step, task_params: list[dict[str, str]]) -> None
 
     # Collect the names of all of the task parameters defined in the step.
     if step.parameterSpace is not None:
-        parameter_space = StepParameterSpaceIterator(space=step.parameterSpace)
-        task_parameter_names: set[str] = set(parameter_space.names)
+        param_space_iter = StepParameterSpaceIterator(space=step.parameterSpace)
+        task_parameter_names: set[str] = set(param_space_iter.names)
     else:
         task_parameter_names = set[str]()
 
@@ -298,7 +297,6 @@ def _validate_task_params(step: Step, task_params: list[dict[str, str]]) -> None
             error_list.append(
                 f"Task {i} is missing values for parameters: {', '.join(sorted(missing_names))}"
             )
-
     if error_list:
         error_msg = "Errors defining task parameter values:\n - "
         error_msg += "\n - ".join(error_list)

--- a/src/openjd/cli/_schema/_schema_command.py
+++ b/src/openjd/cli/_schema/_schema_command.py
@@ -59,10 +59,7 @@ def do_get_schema(args: Namespace) -> OpenJDCliResult:
     schema_doc: dict = {}
 
     try:
-        # The `schema` attribute will have to be updated if/when Pydantic
-        # is updated to v2.
-        # (AFAIK it can be replaced with `model_json_schema()`.)
-        schema_doc = Template.schema()
+        schema_doc = Template.model_json_schema()
         _process_regex(schema_doc)
     except Exception as e:
         return OpenJDCliResult(status="error", message=f"ERROR generating schema: {str(e)}")

--- a/test/openjd/cli/test_common.py
+++ b/test/openjd/cli/test_common.py
@@ -26,7 +26,7 @@ from openjd.cli._common import (
 from openjd.cli._common._job_from_template import job_from_template
 from openjd.model import (
     DecodeValidationError,
-    decode_template,
+    decode_job_template,
 )
 
 
@@ -364,11 +364,13 @@ def test_job_from_template_success(
     Test that `job_from_template` creates a Job with the provided parameters.
     """
     template_dir, current_working_dir = template_dir_and_cwd
-    template = decode_template(template=template_dict)
+    template = decode_job_template(template=template_dict)
 
     result = job_from_template(template, mock_params, template_dir, current_working_dir)
     assert result.name == expected_job_name
-    assert result.steps == template.steps
+    assert [step.model_dump(exclude_none=True) for step in result.steps] == [
+        step.model_dump(exclude_none=True) for step in template.steps
+    ]
     if result.parameters:
         assert len(result.parameters) == len(mock_params)
 
@@ -410,7 +412,7 @@ def test_job_from_template_error(
     """
     template_dir, current_working_dir = template_dir_and_cwd
 
-    template = decode_template(template=template_dict)
+    template = decode_job_template(template=template_dict)
 
     with pytest.raises(RuntimeError) as rte:
         job_from_template(template, mock_params, template_dir, current_working_dir)

--- a/test/openjd/cli/test_schema_command.py
+++ b/test/openjd/cli/test_schema_command.py
@@ -2,7 +2,7 @@
 
 from openjd.cli._schema._schema_command import do_get_schema, _process_regex
 from openjd.model import TemplateSpecificationVersion
-from pydantic.v1 import BaseModel
+import openjd.model.v2023_09
 
 from argparse import Namespace
 import json
@@ -129,9 +129,10 @@ def test_do_get_schema_error(capsys: pytest.CaptureFixture):
     """
 
     with (
-        patch.object(BaseModel, "schema", side_effect=RuntimeError("Test error")),
+        patch.object(openjd.model.v2023_09, "JobTemplate") as job_template_class,
         pytest.raises(SystemExit),
     ):
+        job_template_class.model_json_schema.side_effect = RuntimeError("Test error")
         do_get_schema(
             Namespace(
                 version=TemplateSpecificationVersion.JOBTEMPLATE_v2023_09.value,

--- a/test/openjd/cli/test_summary_command.py
+++ b/test/openjd/cli/test_summary_command.py
@@ -21,7 +21,7 @@ from openjd.model import (
     ParameterValue,
     ParameterValueType,
     create_job,
-    decode_template,
+    decode_job_template,
 )
 
 
@@ -236,7 +236,7 @@ def test_get_output_step_summary_success(
     """
     Test that `output_summary_result` returns an object with the expected values when called with a Step.
     """
-    template = decode_template(template=template_dict)
+    template = decode_job_template(template=template_dict)
     job = create_job(job_template=template, job_parameter_values=mock_job_params)
 
     response = output_summary_result(job, step_name)
@@ -256,7 +256,7 @@ def test_output_step_summary_result_error():
     Test that `output_summary_result` throws an error if a non-existent Step name is provided.
     (function only has one error state)
     """
-    template = decode_template(template=MOCK_TEMPLATE)
+    template = decode_job_template(template=MOCK_TEMPLATE)
     job = create_job(job_template=template, job_parameter_values={})
 
     response = output_summary_result(job, "no step")
@@ -452,7 +452,7 @@ def test_output_job_summary_result_success(
     """
     Test that `output_summary_result` returns an object with the expected values when called on a Job.
     """
-    template = decode_template(template=template_dict)
+    template = decode_job_template(template=template_dict)
     job = create_job(job_template=template, job_parameter_values=mock_params)
 
     response = output_summary_result(job)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The CLI depends on some implementation details of Pydantic V1 that have changed in V2. Need to update to match https://github.com/OpenJobDescription/openjd-model-for-python/pull/164.

### What was the solution? (How)

Modify the code to work with the Pydantic V2 openjd-model.

### What is the impact of this change?

The CLI will continue to work after the Pydantic V2 upgrade

### How was this change tested?

- Have you run the tests?

Yes

### Was this change documented?

N/A

### Is this a breaking change?

No, nothing about the CLI interface is changing.

This is an update to match a breaking change in the openjd-model library. That change is breaking because its interface is based on Pydantic, so code that depends on details that differ in V2 need to be updated.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats
   
No security impacts.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*