### PR TITLE
test: Reduce --maximum-tasks value in test to improve reliability

### DIFF
--- a/test/openjd/cli/test_chunked_job.py
+++ b/test/openjd/cli/test_chunked_job.py
@@ -84,7 +84,7 @@ def test_openjd_run_on_chunked_job_default_options(capsys):
 
 def test_openjd_run_on_chunked_job_adaptive_chunking(capsys):
     # Test that running chunked_job.yaml with adaptive chunking and the TargetRuntime cranked really high
-    # resutls in two chunks, the first being one task, and the second being the remainder.
+    # results in two chunks, the first being one task, and the second being the remainder.
 
     expected_message_regex_list = [
         r"Item\(CHUNK\[INT\]\) = 1$",
@@ -119,7 +119,7 @@ def test_openjd_run_on_chunked_job_maximum_task_count(capsys, target_runtime):
     # Runs with TargetRuntime=0 (fixed chunk size) and TargetRuntime=1 (adaptive chunk size) to
     # exercise both task running inner loops.
     expected_message_regex_list = [
-        "Chunks run: 5$",
+        "Chunks run: 3$",
     ]
 
     outerr = run_openjd_cli_main(
@@ -134,7 +134,7 @@ def test_openjd_run_on_chunked_job_maximum_task_count(capsys, target_runtime):
             "-p",
             f"TargetRuntime={target_runtime}",
             "--maximum-tasks",
-            "5",
+            "3",
         ],
         expected_exit_code=0,
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Getting a failure on MacOS w/ Python 3.10: https://github.com/OpenJobDescription/openjd-cli/actions/runs/13726827750/job/38395460029?pr=139

### What was the solution? (How)

The tasks were running fast enough to only need 4 tasks. Change the maximum set to 3 instead.

### What is the impact of this change?

More reliable tests.

### How was this change tested?

Ran the tests.

### Was this change documented?

N/A

### Is this a breaking change?

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*