### PR TITLE
chore: add missing breaking change notice to v0.6.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 0.6.0 (2025-03-07)
 
+### BREAKING CHANGES
+* The logging output has changed to use relative timestamps by default, and print more messages about the job and steps that are running.
 
 ### Features
 * Support adaptive chunking, general CLI improvement ([`664d008`](https://github.com/OpenJobDescription/openjd-cli/commit/664d0083c0e9d2d973a88e1e630e2af6cef67cc1))
-
 
 ## 0.5.1 (2025-02-26)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The changelog for release `0.6.0` was missing a breaking change notice.

### What was the solution? (How)

Added the missed breaking change notification to `CHANGELOG.md`.

### What is the impact of this change?

The changelog now includes the breaking change notification so that readers can better discover it.

### How was this change tested?

Previewed the change in the PR.

### Was this change documented?

N/A

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*