### PR TITLE
fix: Usage of __main__.py is not idiomatic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Source = "https://github.com/OpenJobDescription/openjd-cli"
 
 
 [project.scripts]
-openjd = "openjd:__main__.main"
+openjd = "openjd.cli:main"
 
 
 [tool.hatch.build]


### PR DESCRIPTION
Fixes: https://github.com/OpenJobDescription/openjd-cli/issues/143

### What was the problem/requirement? (What/Why)

In https://docs.python.org/3/library/__main__.html#main-py-in-python-packages it says:

> The content of `__main__.py` typically isn’t fenced with an
> `if __name__ == '__main__'` block. Instead, those files are kept
> short and import functions to execute from other modules.
> Those other modules can then be easily unit-tested and are properly reusable.

and later

> This won’t work for `__main__.py` files in the root directory of a .zip file
> though. Hence, for consistency, a minimal `__main__.py` without a `__name__`
> check is preferred.

In the last release, we updated `__main__.py` to be idiomatic, but missed that the pyproject.toml file required the script to be non-idiomatic.

### What was the solution? (How)

This fix corrects usage in pyproject.toml to be idiomatic.

### What is the impact of this change?

Using the `openjd` command should no longer run it twice.

### How was this change tested?

I ran `hatch build` to create a .whl. Installed that .whl into a virtual environment, and confirmed the resulting `openjd` command worked as expected.

### Was this change documented?

N/A

### Is this a breaking change?

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*