### PR TITLE
chore: change publish to pypi to use tag ref instead of release branch.

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -64,7 +64,7 @@ jobs:
         tag: ${{ needs.TagRelease.outputs.tag }}
         
   PublishToPyPI:
-    needs: Publish
+    needs: [TagRelease, Publish]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: release
+          ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The PublishToPyPI job was still pointing to the release branch. It should be looking at a tag now. 

### What was the solution? (How)

Change the reference to point to tag created during the PublishToPyPI job. It should be noted that the Publish job doesn't have an output anymore, so we need to use the output from TagRelease. (The other jobs in here also use the tag output from TagRelease). 

### What is the impact of this change?

Allow for PyPi releases./

### How was this change tested?

N/A

### Was this change documented?

No.

### Is this a breaking change?

No.

### Does this change impact security?

No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*