### PR TITLE
fix: renable zero versions for semantic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ omit= [
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The latest version of semantic versioning disables zero versions by default (a change in previous behavior)

### What was the solution? (How)
Enable it again with a config setting.

### What is the impact of this change?
Release versions will be calculated properly.

### How was this change tested?

- Have you run the tests?
   - Yes, all unit tests pass.

### Was this change documented?

N/A

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*