### PR TITLE
feat: Add version argument

### DIFF
--- a/src/openjd/cli/_create_argparser.py
+++ b/src/openjd/cli/_create_argparser.py
@@ -5,6 +5,8 @@ import sys
 import traceback
 from typing import Optional
 
+from ._version import version
+
 from ._common import SubparserGroup
 
 from ._check import populate_argparser as populate_check_subparser
@@ -22,6 +24,11 @@ def create_argparser() -> ArgumentParser:
     """Generate the root argparser for the CLI"""
     parser = ArgumentParser(prog="openjd", usage="openjd <command> [arguments]")
     parser.set_defaults(func=lambda _: parser.print_help())
+
+    parser.add_argument(
+        "--version", action="version", version=f"Open Job Description CLI {version}"
+    )
+
     subcommands = SubparserGroup(
         parser,
         title="commands",


### PR DESCRIPTION
Fixes: https://github.com/OpenJobDescription/openjd-cli/issues/185

### What was the problem/requirement? (What/Why)
No easy way to see the version of OpenJD CLI you're using

### What was the solution? (How)
Add a `--version` argument :^)

### What is the impact of this change?
Having a version command makes it:
- Easier to diagnose & report errors
- Easier to verify developers are testing the right pre-release versions

### How was this change tested?
Ran unit tests

### Was this change documented?
n/a

### Is this a breaking change?

nop

### Does this change impact security?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*