### PR TITLE
feat: Treat job template extensions other than .json as YAML

### DIFF
--- a/src/openjd/cli/_common/_validation_utils.py
+++ b/src/openjd/cli/_common/_validation_utils.py
@@ -15,11 +15,12 @@ from openjd.model import (
 
 
 def get_doc_type(filepath: Path) -> DocumentType:
+    # If the file has a .json extension, treat it strictly
+    # as JSON, otherwise treat it as YAML.
     if filepath.suffix.lower() == ".json":
         return DocumentType.JSON
-    elif filepath.suffix.lower() in (".yaml", ".yml"):
+    else:
         return DocumentType.YAML
-    raise RuntimeError(f"'{str(filepath)}' is not JSON or YAML.")
 
 
 def read_template(template_file: Path) -> dict[str, Any]:

--- a/test/openjd/cli/test_common.py
+++ b/test/openjd/cli/test_common.py
@@ -50,6 +50,7 @@ def template_dir_and_cwd():
     [
         pytest.param(".template.json", json.dump, id="Successful JSON"),
         pytest.param(".template.yaml", yaml.dump, id="Successful YAML"),
+        pytest.param(".ojdt", yaml.dump, id="Successful YAML with alternate extension"),
     ],
 )
 def test_read_template_success(tempfile_extension: str, doc_serializer: Callable):
@@ -119,6 +120,12 @@ def test_read_template_fileerror(
             'specificationVersion: "jobtemplate-2023-09"\n',
             id="YAML missing field",
         ),
+        pytest.param(
+            # Extensions other than .json are treated as YAML
+            ".template.ojdt",
+            'specificationVersion: "jobtemplate-2023-09"\n',
+            id="YAML missing field",
+        ),
     ],
 )
 def test_read_job_template_parsingerror(tempfile_extension: str, file_contents: str):
@@ -149,6 +156,12 @@ def test_read_job_template_parsingerror(tempfile_extension: str, file_contents: 
         ),
         pytest.param(
             ".template.yaml",
+            'specificationVersion: "environment-2023-09"\n',
+            id="YAML missing field",
+        ),
+        pytest.param(
+            # Extensions other than .json are treated as YAML
+            ".template.ojde",
             'specificationVersion: "environment-2023-09"\n',
             id="YAML missing field",
         ),
@@ -242,15 +255,6 @@ def test_get_job_params_success(mock_param_args: list[str], expected_param_value
             None,
             "is not a file",
             id="Parameter filepath is not a file",
-        ),
-        pytest.param(
-            ["file://some-image.png"],
-            True,
-            True,
-            "some-image.png",
-            None,
-            "is not JSON or YAML",
-            id="Parameter filepath is not JSON/YAML",
         ),
         pytest.param(
             ["file://forbidden-file.json"],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Currently, the `openjd run` and other commands will fail if the job template they receive has an extension different from .json, .yml, or .yaml. It would be nice to be able to use other file extensions as well.

### What was the solution? (How)

This change treats all non-.json extensions as YAML, so that job templates can be named with different extensions like `.ojdt` that clearly distinguish them from generic JSON or YAML.

### What is the impact of this change?

More flexible usage of the `openjd` CLI.

### How was this change tested?

Ran `openjd run` with job templates that have a different extension than `.yaml` or `.json`. Saw that the failing cases now worked.

### Was this change documented?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*