### PR TITLE
doc: clarify help text for --extensions

### DIFF
--- a/src/openjd/cli/_common/_extensions.py
+++ b/src/openjd/cli/_common/_extensions.py
@@ -10,7 +10,7 @@ SUPPORTED_EXTENSIONS = ["TASK_CHUNKING", "REDACTED_ENV_VARS", "FEATURE_BUNDLE_1"
 def add_extensions_argument(run_parser: ArgumentParser):
     run_parser.add_argument(
         "--extensions",
-        help=f"A comma-separated list of Open Job Description extension names to enable. Defaults to all that are implemented: {','.join(SUPPORTED_EXTENSIONS)}",
+        help=f"A comma-separated list of Open Job Description extension names that the CLI will accept from job templates. Templates declare which extensions they use. Defaults to all that are implemented: {','.join(SUPPORTED_EXTENSIONS)}",
     )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `--extensions` parameter help text is confusing. I didn't understand how it interacted with the extensions list in job attachments.

### What was the solution? (How)
Clarify the text.

### What is the impact of this change?
Easier to use.

### How was this change tested?
n/a

### Was this change documented?
Yes

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*