### PR TITLE
chore: temporary pin virtualenv<21 to fix build

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -81,7 +81,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 pip install --upgrade twine
 hatch run lint
 hatch run test


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

virtualenv 21.0.0 released which is breaking hatch commands. See https://github.com/pypa/hatch/issues/2193

### What was the solution? (How)

Pin virtualenv to <21 for now

### What is the impact of this change?

hatch commands work again

### How was this change tested?

Ran hatch build with virtualenv<21 successfully

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
