### PR TITLE
feat: Support RFC extensions in environment templates

### DIFF
--- a/src/openjd/cli/_check/_check_command.py
+++ b/src/openjd/cli/_check/_check_command.py
@@ -41,7 +41,10 @@ def do_check(args: Namespace) -> OpenJDCliResult:
         if TemplateSpecificationVersion.is_job_template(template_version):
             decode_job_template(template=template_object, supported_extensions=extensions)
         elif TemplateSpecificationVersion.is_environment_template(template_version):
-            decode_environment_template(template=template_object)
+            # Pass `extensions` so env templates can declare e.g.
+            # WRAP_ACTIONS (RFC 0008) — without this the model rejects
+            # the extension declaration even though the CLI accepts it.
+            decode_environment_template(template=template_object, supported_extensions=extensions)
         else:
             return OpenJDCliResult(
                 status="error",

--- a/src/openjd/cli/_common/_extensions.py
+++ b/src/openjd/cli/_common/_extensions.py
@@ -3,8 +3,17 @@
 from argparse import ArgumentParser
 from typing import Optional
 
-# This is the list of Open Job Description extensions with implemented support
-SUPPORTED_EXTENSIONS = ["TASK_CHUNKING", "REDACTED_ENV_VARS", "FEATURE_BUNDLE_1"]
+# This is the list of Open Job Description extensions with implemented support.
+# EXPR (RFCs 0005/0006) and WRAP_ACTIONS (RFC 0008) are added so the CLI can run
+# templates that declare them. WRAP_ACTIONS implies EXPR; the model library
+# handles that implication when it parses the template.
+SUPPORTED_EXTENSIONS = [
+    "TASK_CHUNKING",
+    "REDACTED_ENV_VARS",
+    "FEATURE_BUNDLE_1",
+    "EXPR",
+    "WRAP_ACTIONS",
+]
 
 
 def add_extensions_argument(run_parser: ArgumentParser):

--- a/src/openjd/cli/_common/_validation_utils.py
+++ b/src/openjd/cli/_common/_validation_utils.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from typing import Any
+from typing import Any, Optional
 from pathlib import Path
 
 from openjd.model import (
@@ -70,15 +70,29 @@ def read_job_template(template_file: Path, *, supported_extensions: list[str]) -
     return template
 
 
-def read_environment_template(template_file: Path) -> EnvironmentTemplate:
+def read_environment_template(
+    template_file: Path,
+    *,
+    supported_extensions: Optional[list[str]] = None,
+) -> EnvironmentTemplate:
     """Open a JSON or YAML-formatted file and attempt to parse it into an EnvironmentTemplate object.
     Raises a RuntimeError if the file doesn't exist or can't be opened, and raises a
     DecodeValidationError if its contents can't be parsed into a valid EnvironmentTemplate.
+
+    Environment templates may declare extensions just like job templates do
+    (e.g. ``WRAP_ACTIONS`` for RFC 0008's wrap hooks). Pass the CLI's allow-list
+    via ``supported_extensions`` so the model accepts those declarations;
+    omitting the argument preserves the legacy behavior of accepting only the
+    default model surface.
     """
     # Raises RuntimeError
     template_object = read_template(template_file)
 
+    decode_kwargs: dict[str, list[str]] = {}
+    if supported_extensions is not None:
+        decode_kwargs["supported_extensions"] = supported_extensions
+
     # Raises: DecodeValidationError
-    template = decode_environment_template(template=template_object)
+    template = decode_environment_template(template=template_object, **decode_kwargs)
 
     return template

--- a/src/openjd/cli/_run/_run_command.py
+++ b/src/openjd/cli/_run/_run_command.py
@@ -415,7 +415,11 @@ def do_run(args: Namespace) -> OpenJDCliResult:
             filename = Path(env).expanduser()
             try:
                 # Raises: RuntimeError, DecodeValidationError
-                env_template = read_environment_template(filename)
+                # Pass `extensions` so env templates can declare e.g.
+                # WRAP_ACTIONS (RFC 0008) — without this they're parsed
+                # against the default model surface and reject the
+                # extension declaration.
+                env_template = read_environment_template(filename, supported_extensions=extensions)
                 environments.append(env_template)
             except (RuntimeError, DecodeValidationError) as e:
                 return OpenJDCliResult(status="error", message=str(e))


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `run` and `check` commands accept an `--extensions` allow-list, but that list was only applied when decoding **job** templates. **Environment** templates were always decoded against the default model surface, ignoring the requested extensions. As a result, an environment template that declares an extension (for example `WRAP_ACTIONS` from RFC 0008, or `EXPR` from RFCs 0005/0006) was rejected with a validation error even when the user explicitly requested that extension on the command line.

Additionally, `EXPR` and `WRAP_ACTIONS` were not present in the CLI's `SUPPORTED_EXTENSIONS` allow-list, so they could not be enabled at all.

### What was the solution? (How)

- Added `EXPR` and `WRAP_ACTIONS` to `SUPPORTED_EXTENSIONS` in `_common/_extensions.py`. `WRAP_ACTIONS` implies `EXPR`; the model library handles that implication when parsing.
- `read_environment_template()` in `_common/_validation_utils.py` now accepts an optional, keyword-only `supported_extensions` argument and forwards it to `decode_environment_template`. When omitted, the previous behavior (default model surface only) is preserved.
- `do_run` (`_run/_run_command.py`) and `do_check` (`_check/_check_command.py`) now pass the parsed `extensions` when decoding environment templates, matching how job templates are already handled.

### What is the impact of this change?

Environment templates that declare supported extensions now validate and run correctly through `openjd run --environment ...` and `openjd check ...`, consistent with job-template behavior. Behavior is unchanged for templates that do not declare extensions.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-cli/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the tests? Yes. `hatch run lint` (ruff, black `--check`, mypy) passes clean, and the full unit test suite passes: **289 passed, 2 skipped**, total coverage 93.4% (above the 92% gate).

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes. The `read_environment_template` docstring documents the new `supported_extensions` argument, and inline comments at each call site explain why extensions are forwarded.

### Is this a breaking change?

No. `read_environment_template` gained a new optional keyword-only parameter that defaults to the previous behavior, so existing callers are unaffected. No public contract is changed in a backwards-incompatible way.

### Does this change impact security?

No. The change only forwards an existing, user-supplied extension allow-list to the environment-template decoder; it does not create or modify files/directories or alter permission handling.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*