### PR TITLE
chore(deps): combine and fix up dependabot bumps (black 26, mypy 2, pytest 9)

### DIFF
--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -29,6 +29,7 @@ Running this script on the above CHANGELOG.md should return the following conten
 
 ```
 """
+
 import re
 
 h2 = r"^##\s.*$"

--- a/hatch_version_hook.py
+++ b/hatch_version_hook.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from typing import Any, Optional
 
-
 _logger = logging.Logger(__name__, logging.INFO)
 _stdout_handler = logging.StreamHandler(sys.stdout)
 _stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,9 +1,12 @@
 coverage[toml] == 7.*
-pytest == 8.4.*
+pytest == 9.1.*; python_version >= "3.10"
+pytest == 8.4.*; python_version < "3.10"
 pytest-cov == 7.1.*
 pytest-timeout == 2.4.*
 pytest-xdist == 3.8.*
 types-PyYAML == 6.*
-black == 25.*
-mypy == 1.19.*
+black == 26.*; python_version >= "3.10"
+black == 25.*; python_version < "3.10"
+mypy == 2.1.*; python_version >= "3.10"
+mypy == 1.19.*; python_version < "3.10"
 ruff == 0.15.*

--- a/src/openjd/__main__.py
+++ b/src/openjd/__main__.py
@@ -2,5 +2,4 @@
 
 from .cli._create_argparser import main
 
-
 main()

--- a/src/openjd/cli/_create_argparser.py
+++ b/src/openjd/cli/_create_argparser.py
@@ -14,7 +14,6 @@ from ._summary import populate_argparser as populate_summary_subparser
 from ._run import populate_argparser as populate_run_subparser
 from ._schema import populate_argparser as populate_schema_subparser
 
-
 # Our CLI subcommand construction requires that all leaf subcommands define a default
 # 'func' property which is a Callable[[],None] that implements the subcommand.
 # After parsing, we call that `func` argument of the resulting args object.

--- a/test/openjd/cli/test_run_command.py
+++ b/test/openjd/cli/test_run_command.py
@@ -23,7 +23,6 @@ from openjd.cli._run._run_command import (
 from openjd.cli._run._local_session._session_manager import LoggingTimestampFormat
 from openjd.sessions import LOG as SessionsLogger, PathMappingRule, PathFormat
 
-
 PARAMETRIZE_CASES: tuple = (
     pytest.param(
         "basic.yaml",


### PR DESCRIPTION
Combining and fixing up the three failing dependabot PRs (#218, #219, #222) so they can be closed.

## Changes (`requirements-testing.txt`)
- **black `25.*` -> `26.*`** (#218)
- **mypy `1.19.*` -> `2.1.*`** (#219)
- **pytest `8.4.*` -> `9.1.*`** (#222)

## Why the individual PRs were failing
black 26, mypy 2, and pytest 9 all dropped Python 3.9 (they now require `>=3.10`), but this package supports `>=3.9` and tests 3.9 in CI — so pip couldn't install them on the 3.9 job.

## Fix: environment markers
Each tool is pinned per Python version so the 3.9 job installs the last 3.9-compatible release and 3.10+ gets the upgraded major:
```
pytest == 9.1.*; python_version >= "3.10"
pytest == 8.4.*; python_version < "3.10"
black == 26.*; python_version >= "3.10"
black == 25.*; python_version < "3.10"
mypy == 2.1.*; python_version >= "3.10"
mypy == 1.19.*; python_version < "3.10"
```
Also applied black 26's docstring blank-line reformatting (5 files); verified black 25 agrees with the reformatted tree, so the 3.9 `black --check` job stays green.

## Verification
- `ruff check` / `black --check` — pass
- `mypy` (2.1.0) — no issues in 37 source files
- `hatch run test` — 289 passed, 2 skipped

Closes #218, closes #219, closes #222.