### PR TITLE
chore(dependabot): group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
       day: "monday"
     commit-message: 
       prefix: "chore(deps):"
+    # Combine all minor and patch bumps into a single PR. Major bumps do not
+    # match this group and so each get their own individual PR.
+    groups:
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
@@ -19,3 +28,12 @@ updates:
       day: "monday"
     commit-message: 
       prefix: "chore(github):"
+    # Combine all minor and patch bumps into a single PR. Major bumps do not
+    # match this group and so each get their own individual PR.
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Fixes: *N/A*

### What was the problem/requirement? (What/Why)

We get a lot of Dependabot PRs for minor and patch version bumps. Each one has to be reviewed and rebase-merged individually, which creates a lot of churn.

### What was the solution? (How)

Use Dependabot [groups](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--) in `.github/dependabot.yml` to combine all minor and patch updates into a single PR per ecosystem (`pip` and `github-actions`). Major version bumps do not match the group and continue to get individual PRs. See also [Example 3: Individual pull requests for major updates and grouped for minor/patch updates](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates).

This mirrors OpenJobDescription/openjd-rs#273; the resulting effect can be seen in OpenJobDescription/openjd-rs#275.

### What is the impact of this change?

Fewer Dependabot PRs and a better update experience.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-cli/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the tests? N/A — this is a config-only change to `.github/dependabot.yml`, validated as well-formed YAML. No unit or integration tests apply. The same approach is already in effect in openjd-rs (OpenJobDescription/openjd-rs#275).

### Was this change documented?

- Are relevant docstrings in the code base updated? N/A — config-only change.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
